### PR TITLE
Add Inspection Infrastructure (pre-rendered depth maps)

### DIFF
--- a/backend/app/image_renderer/camera_pos_utils.py
+++ b/backend/app/image_renderer/camera_pos_utils.py
@@ -280,11 +280,19 @@ class ImagesMeta:
 
         return filtered_files
 
-    def get_pose_by_filename(self, filename):
+    def get_pose_by_filename(self, filename, colmap=False):
+        """
+        :param filename: filename of the image
+        :param colmap: boolean flag to indicate whether to return in original colmap convention (i.e., T_w_c)
+        """
         idx = self.files.index(filename)
         R = Rotation.from_quat(self.q_vec[idx][[1, 2, 3, 0]]).as_matrix()
-        R = np.linalg.inv(R)
-        return compose_44(R, self.cam_centers[idx])
+        if colmap:
+            t = self.t_vec[idx]
+        else:
+            R = np.linalg.inv(R)
+            t = self.cam_centers[idx]
+        return compose_44(R, t)
 
     def qvec2rotmat(self, qvec):
         return np.array(

--- a/backend/app/image_renderer/camera_pos_utils.py
+++ b/backend/app/image_renderer/camera_pos_utils.py
@@ -225,14 +225,24 @@ def check_occlusion(pts3d_w, depth, K, R_w_c, t_w_c, w, h, occlusion_tol=0):
 
 
 class ImagesMeta:
-    def __init__(self, file):
+    def __init__(self, images_txt_file, cameras_txt_file):
         self.img_id = []
         self.files = []
         self.t_vec = []
         self.q_vec = []
+        self.camera_id = []
         self.cam_centers = []
+        self.cameras_params = {}
 
-        with open(file, 'r') as f:
+        with open(cameras_txt_file, 'r') as f:
+            for count, line in enumerate(f, start=0):
+                if count < 3:
+                    pass
+            else:
+                str_parsed = line.split()
+                self.cameras_params[str_parsed[0]] = [str_parsed[1], int(str_parsed[2]), int(str_parsed[3]), np.array(tuple(map(float, str_parsed[4:])))]
+
+        with open(images_txt_file, 'r') as f:
             for count, line in enumerate(f, start=0):
                 if count < 4:
                     pass
@@ -244,6 +254,7 @@ class ImagesMeta:
                         q_raw = np.array(str_parsed[1:5], dtype=np.float32)
                         R_raw = self.qvec2rotmat(q_raw)
                         t_raw = np.array(str_parsed[5:8], dtype=np.float32)
+                        self.camera_id.append(int(str_parsed[8]))
                         cam_center = (-R_raw.T @ t_raw)
                         self.q_vec.append(q_raw)
                         self.t_vec.append(t_raw)
@@ -420,5 +431,5 @@ if __name__ == '__main__':
                       [-0.68636268, 0.42995355, -0.58655453]])
     T_vec = np.array([-0.32326042, -3.65895232, 2.27446875])
     init_pose = compose_44(R_mat, T_vec)
-    imagelocs = ImagesMeta("/home/cviss/PycharmProjects/GS_Stream/data/UW_tower/sparse/0/images.txt")
+    imagelocs = ImagesMeta("/home/cviss/PycharmProjects/GS_Stream/data/UW_Health_Tower/reconstruction/sparse/0/images.txt", "/home/cviss/PycharmProjects/GS_Stream/data/UW_Health_Tower/reconstruction/sparse/0/cameras.txt")
     print(imagelocs.get_closest_n(init_pose))

--- a/backend/app/image_renderer/render_wrapper.py
+++ b/backend/app/image_renderer/render_wrapper.py
@@ -4,6 +4,7 @@ import yaml
 import numpy as np
 import torch
 import torchvision
+import gzip
 
 from gaussian_renderer import GaussianModel, render
 from utils.graphics_utils import getProjectionMatrix, getWorld2View2
@@ -59,6 +60,7 @@ class GS_Model():
         self.images = None
         self._R_mat = np.array(eval(R_mat))
         self._T_vec = np.array(eval(T_vec))
+        self._depth_avail = False
 
         with open(config_path, "r") as f:
             config = yaml.safe_load(f)
@@ -67,6 +69,10 @@ class GS_Model():
             self.images = ImagesMeta(config["images_txt_path"], config["cameras_txt_path"])
             self.images_files = config["images_dir"]
             self.images_thumbnails = config["images_dir_thumbnails"]
+
+        if config["depth_dir"] != "NA":
+            self.depth_files = config["depth_dir"]
+            self._depth_avail = True
 
         self.p1 = np.array(config["alt_and_heading"]["gnd_points"]["p1"])
         self.v1 = np.array(config["alt_and_heading"]["gnd_vectors"]["v1"])

--- a/backend/app/image_renderer/render_wrapper.py
+++ b/backend/app/image_renderer/render_wrapper.py
@@ -7,7 +7,7 @@ import torchvision
 
 from gaussian_renderer import GaussianModel, render
 from utils.graphics_utils import getProjectionMatrix, getWorld2View2
-from .camera_pos_utils import ImagesMeta, compose_44, decompose_44, pt_2_plane_dist, r_2_yaw
+from backend.app.image_renderer.camera_pos_utils import ImagesMeta, compose_44, decompose_44, pt_2_plane_dist, r_2_yaw
 
 class DummyPipeline:
     convert_SHs_python = False
@@ -63,8 +63,8 @@ class GS_Model():
         with open(config_path, "r") as f:
             config = yaml.safe_load(f)
 
-        if config["images_txt_path"] is not None:
-            self.images = ImagesMeta(config["images_txt_path"])
+        if config["images_txt_path"] is not None and config["cameras_txt_path"] is not None:
+            self.images = ImagesMeta(config["images_txt_path"], config["cameras_txt_path"])
             self.images_files = config["images_dir"]
             self.images_thumbnails = config["images_dir_thumbnails"]
 
@@ -158,7 +158,7 @@ class GS_Model():
 if __name__ == '__main__':
     from backend.app.model_config.model_config_fetcher import model_manager
     
-    model_id = "101" # You can change this to any model id. This is just for testing purposes
+    model_id = "103" # You can change this to any model id. This is just for testing purposes
     model_manager.set_model(model_id)
     model = model_manager.get_model(model_id)
     

--- a/scripts/create_yaml.py
+++ b/scripts/create_yaml.py
@@ -229,6 +229,7 @@ def main_dji(args):
         data = {
             "ply_path": path.abspath(args.ply_path),
             "images_txt_path": path.abspath(args.images_txt_path),
+            "cameras_txt_path": path.abspath(args.cameras_txt_path),
             "images_dir": path.abspath(args.images_dir),
             "images_dir_thumbnails": path.abspath(args.images_dir_thumbnails),
             "alt_and_heading": {
@@ -253,6 +254,8 @@ if __name__ == '__main__':
                         default="../output/RCH/splat/iteration_30000/cropped.ply")
     parser.add_argument('-img_txt', '--images_txt_path', type=str, help="path to images.txt file",
                         default="../output/RCH/sparse/0/images.txt")
+    parser.add_argument('-cams_txt', '--cameras_txt_path', type=str, help="path to cameras.txt file",
+                        default="../output/RCH/sparse/0/cameras.txt")
     parser.add_argument('-img_dir', '--images_dir', type=str, help="path of images folder",
                         default="../output/RCH/images")
     parser.add_argument('-img_dir_thumb', "--images_dir_thumbnails", type=str,

--- a/scripts/create_yaml.py
+++ b/scripts/create_yaml.py
@@ -159,7 +159,6 @@ def create_thumbnails(images_dir: str, thumbnails_dir: str, max_dim: int = 500):
 
 def main_dji(args):
     create_thumbnails(args.images_dir, args.images_dir_thumbnails, 250)
-
     if args.dji:
         points = read_gnd_points(args.plane_points_file)
 
@@ -213,6 +212,7 @@ def main_dji(args):
         data = {
             "ply_path": path.abspath(args.ply_path),
             "images_txt_path": path.abspath(args.images_txt_path),
+            "cameras_txt_path": path.abspath(args.cameras_txt_path),
             "images_dir": path.abspath(args.images_dir),
             "images_dir_thumbnails": path.abspath(args.images_dir_thumbnails),
             "alt_and_heading": {
@@ -243,6 +243,11 @@ def main_dji(args):
             }
         }
 
+    if args.depth_dir is not None:
+        data["depth_dir"] = path.abspath(args.depth_dir)
+    else:
+        data["depth_dir"] = "NA"
+
     with open(path.join(args.config_path, 'config.yaml'), 'w') as outfile:
         yaml = YAML()
         yaml.default_flow_style = False
@@ -260,9 +265,10 @@ if __name__ == '__main__':
                         default="../output/RCH/images")
     parser.add_argument('-img_dir_thumb', "--images_dir_thumbnails", type=str,
                         help="path of thumbnails folder", default="../output/RCH/images_thumbnails")
+    parser.add_argument('-depth_dir', '--depth_dir', type=str, help="path of depth folder", default=None)
     parser.add_argument('-gnd_pts', "--plane_points_file", type=str,
                         help="path to <projectid>_plane_points.txt file", default="../output/RCH/plane_points.txt")
     parser.add_argument('-config_path', "--config_path", type=str, help="path to save config file")
-    parser.add_argument('-dji', "--dji", type=bool, help="Is DJI images?", default=True)
+    parser.add_argument('-dji', "--dji", type=bool, help="Is DJI images?")
     args = parser.parse_args()
     main_dji(args)


### PR DESCRIPTION
Change to ImagesMeta constructor which now requires paths to images.txt and cameras.txt.

NOTE: config.yaml needs to be updated which can be done manually by adding cameras_txt_path or using updated create_yaml.py in scripts. (This can be improved)

GS_Model now has the properties depth_avail (bool) and depth_dir attributes, which are needed to use inverse_projection function 